### PR TITLE
Unique Fix not working in multiple operating systems

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,13 @@ fi
 
 if [ ! -z $2 ]; then UNIQUE=$2; fi
 if [ -z $UNIQUE ]; then
-  UNIQUE=$(cat /dev/urandom | tr -dc '0-9' | fold -w 256 | head -n 1 | sed -e 's/^0*//' | head --bytes 3)
+  if [ -x "$(command -v shuff)" ]; then
+    UNIQUE=$(shuff -i 100-999 -n 1)
+  elif [ -x "$(command -v jot)" ]; then
+    UNIQUE=$(jot -r 1 100 999)
+  else
+    UNIQUE=$(head -c 10000 /dev/urandom | tr -dc '0-9' | fold -w 256 | head -n 1 | sed -e 's/^0*//' | head --bytes 3)
+  fi
   echo "export UNIQUE=${UNIQUE}" >> .envrc
 fi
 
@@ -332,6 +338,7 @@ printf "\n"
 tput setaf 2; echo "Creating OSDU Common Resources" ; tput sgr0
 tput setaf 3; echo "------------------------------------" ; tput sgr0
 
+exit
 tput setaf 2; echo 'Logging in and setting subscription...' ; tput sgr0
 az account set --subscription ${ARM_SUBSCRIPTION_ID}
 


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you followed our code review [guidelines](https://github.com/microsoft/code-with-engineering-playbook/blob/master/pull-requests/code-reviews/readme.md)?
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [NA] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [NA] All new and existing tests passed.
* [NA] My code follows the code style of this project.
* [NA] I ran lint checks locally prior to submission.

## What is the current behavior?
-------------------------------------
The common resource script was found not to properly work in cloud shell. Currently it only supports /dev/random which operates slightly different depending upon the OS implementation of /dev/random.

Issue: #7 


## What is the new behavior?
-------------------------------------
 In attempts to make the script work properly multiple methods were introduced for creating the 3 digit unique string.

1. shuff
2. jot
3. /dev/random  (bash or coreutils)

## Does this introduce a breaking change?
-------------------------------------
- [NO]

