### PR TITLE
Provider sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ done
   | ARM_SUBSCRIPTION_ID | <your_subscription_id> |
   | TF_VAR_resource_group_location | centralus |
   | TF_VAR_cosmosdb_replica_location | eastus2 |
+  | TF_VAR_elasticsearch_version | 6.8.3 |
 
 > You can specify the desired region locations you wish.
 

--- a/devops/infrastructure/tasks/tests-int.yml
+++ b/devops/infrastructure/tasks/tests-int.yml
@@ -1,4 +1,4 @@
-#  Copyright © Microsoft Corporation
+#  Copyright ï¿½ Microsoft Corporation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ steps:
     env:
       TF_VAR_remote_state_container: $(TF_VAR_remote_state_container)
       TF_VAR_remote_state_account: $(TF_VAR_remote_state_account)
+      TF_VAR_elasticsearch_version: $(TF_VAR_elasticsearch_version)
     condition: not(coalesce(variables.SKIP_TESTS, ${{ parameters.skip }}))
     inputs:
       azureSubscription: '$(SERVICE_CONNECTION_NAME)'

--- a/devops/service-pipelines/tasks/service-detect-cicd.yml
+++ b/devops/service-pipelines/tasks/service-detect-cicd.yml
@@ -58,7 +58,7 @@ steps:
         FILE_CHANGE_SET=$(git diff "$GIT_DIFF_SOURCEBRANCH" "$GIT_DIFF_UPSTREAMBRANCH" --name-only)
         echo "Files changed since last commit..."
         echo "$FILE_CHANGE_SET"
-
+        
         FILTERED_FILE_CHANGE_SET=$(grep -E "$GIT_DIFF_EXTENSION_WHITE_LIST" <<< "$FILE_CHANGE_SET" || true)
         echo "Files changed since last commit, filtered for build-relevant files..."
         echo "$FILTERED_FILE_CHANGE_SET"
@@ -105,10 +105,10 @@ steps:
 
         [ ! -z "${AZURE_CHANGES}" ] && AZURE_CHANGED="yes"
         [ ! -z "${AZURE_TESTS_CHANGES}" ] && AZURE_CHANGED="yes"
-
+        
         [ ! -z "${AWS_CHANGES}" ] && AWS_CHANGED="yes"
         [ ! -z "${AWS_TESTS_CHANGES}" ] && AWS_CHANGED="yes"
-
+        
         [ ! -z "${GCP_CHANGES}" ] && GCP_CHANGED="yes"
         [ ! -z "${GCP_TESTS_CHANGES}" ] && GCP_CHANGED="yes"
 

--- a/devops/service-pipelines/tasks/service-inspect-repository.yml
+++ b/devops/service-pipelines/tasks/service-inspect-repository.yml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 #####################
-# README: Outputs path of maven build directory and also outputs if folder structure of a
+# README: Outputs path of maven build directory and also outputs if folder structure of a 
 #   service is uniplatform (maven dir is in root) or multiplatform (maven dir is in core dir).
 #####################
 

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/otiai10/copy v1.1.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pquerna/otp v1.2.0 // indirect
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/spf13/cobra v0.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484/go.mod h1:Ro8st/El
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fluxcd/flux v1.19.0 h1:QJlUW4gl454u3rNRck+HNvVe0cPk5lEagngvovaUcbM=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -125,6 +126,8 @@ github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.2.0 h1:/A3+Jn+cagqayeR3iHs/L62m5ue7710D35zl1zJ1kok=

--- a/infra/modules/providers/azure/app-gateway/main.tf
+++ b/infra/modules/providers/azure/app-gateway/main.tf
@@ -11,15 +11,6 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-
-data "azurerm_resource_group" "appgateway" {
-  name = var.resource_group_name
-}
-
-data "azurerm_resource_group" "identity_rg" {
-  name = var.user_identity_rg
-}
-
 data "azurerm_client_config" "current" {}
 
 locals {
@@ -32,15 +23,15 @@ locals {
 # Public Ip
 resource "azurerm_public_ip" "appgw_pip" {
   name                = var.appgateway_public_ip_name
-  location            = data.azurerm_resource_group.appgateway.location
-  resource_group_name = data.azurerm_resource_group.appgateway.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
   allocation_method   = "Static"
   sku                 = "Standard"
 }
 
 resource "azurerm_user_assigned_identity" "app_gw_user_identity" {
   resource_group_name = var.user_identity_rg
-  location            = data.azurerm_resource_group.identity_rg.location
+  location            = var.location
   name                = var.user_identity_name
 }
 
@@ -58,8 +49,8 @@ module "app_gw_keyvault_access_policy" {
 
 resource "azurerm_application_gateway" "appgateway" {
   name                = var.appgateway_name
-  resource_group_name = data.azurerm_resource_group.appgateway.name
-  location            = data.azurerm_resource_group.appgateway.location
+  location            = var.location
+  resource_group_name = var.resource_group_name
   tags                = var.resource_tags
 
   sku {

--- a/infra/modules/providers/azure/app-gateway/output.tf
+++ b/infra/modules/providers/azure/app-gateway/output.tf
@@ -41,3 +41,8 @@ output "managed_identity_principal_id" {
   description = "The resource id of the managed user identity"
   value       = azurerm_user_assigned_identity.app_gw_user_identity.principal_id
 }
+
+output "resource_group_name" {
+  description = "The resource group name"
+  value       = azurerm_application_gateway.appgateway.resource_group_name
+}

--- a/infra/modules/providers/azure/app-gateway/tests/integration/appgateway.go
+++ b/infra/modules/providers/azure/app-gateway/tests/integration/appgateway.go
@@ -1,0 +1,78 @@
+//  Copyright © Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-02-01/network"
+	"github.com/microsoft/cobalt/test-harness/infratests"
+	"github.com/microsoft/cobalt/test-harness/terratest-extensions/modules/azure"
+	"github.com/stretchr/testify/require"
+)
+
+var subscription = os.Getenv("ARM_SUBSCRIPTION_ID")
+
+func checkMinCapactiy(t *testing.T, appGatewayProperties *network.ApplicationGatewayPropertiesFormat) {
+	minCapacity := appGatewayProperties.AutoscaleConfiguration.MinCapacity
+	require.Equal(t, int32(2), *minCapacity)
+}
+
+func checkOWASPRuleset(t *testing.T, appGatewayProperties *network.ApplicationGatewayPropertiesFormat) {
+	firewallRulesetType := appGatewayProperties.WebApplicationFirewallConfiguration.RuleSetType
+	firewallRulesetVersion := appGatewayProperties.WebApplicationFirewallConfiguration.RuleSetVersion
+	require.Equal(t, "OWASP", *firewallRulesetType, "Firewall ruleset type is incorrect")
+	require.Equal(t, "3.1", *firewallRulesetVersion, "Firewall ruleset version is incorrect")
+}
+
+func checkAvailablePorts(t *testing.T, appGatewayProperties *network.ApplicationGatewayPropertiesFormat) {
+	foundPort := false
+	frontendPorts := appGatewayProperties.FrontendPorts
+	for _, frontend := range *frontendPorts {
+		if *frontend.Port == int32(443) {
+			foundPort = true
+		}
+	}
+	require.True(t, foundPort, "Failed to find a frontendPort with port 443")
+}
+
+func checkSSLCertificates(t *testing.T, appGatewayProperties *network.ApplicationGatewayPropertiesFormat, keyvaultSecretID string) {
+	certs := appGatewayProperties.SslCertificates
+	require.Equal(t, 1, len(*certs))
+	cert := (*certs)[0]
+	require.Equal(t, "Succeeded", *cert.ProvisioningState)
+	require.Equal(t, keyvaultSecretID, *cert.KeyVaultSecretID)
+}
+
+// InspectAppGateway - Runs a suite of test assertions to validate properties for an application gateway
+func InspectAppGateway(resourceGroupNameOutput string, appGatewayNameOutput string, keyvaultIDOutput string) func(t *testing.T, output infratests.TerraformOutput) {
+	return func(t *testing.T, output infratests.TerraformOutput) {
+		appGatewayName := output[appGatewayNameOutput].(string)
+		resourceGroupName := output[resourceGroupNameOutput].(string)
+		keyvaultSecretID := output[keyvaultIDOutput].(string)
+
+		appGateway, err := azure.GetAppGatewayProperties(subscription, resourceGroupName, appGatewayName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		appGatewayProperties := appGateway.ApplicationGatewayPropertiesFormat
+
+		checkMinCapactiy(t, appGatewayProperties)
+		checkOWASPRuleset(t, appGatewayProperties)
+		checkSSLCertificates(t, appGatewayProperties, keyvaultSecretID)
+	}
+}

--- a/infra/modules/providers/azure/app-gateway/tests/integration/appgateway_test.go
+++ b/infra/modules/providers/azure/app-gateway/tests/integration/appgateway_test.go
@@ -1,0 +1,34 @@
+//  Copyright © Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/microsoft/cobalt/infra/modules/providers/azure/app-gateway/tests"
+	"github.com/microsoft/cobalt/test-harness/infratests"
+)
+
+func TestAppGateway(t *testing.T) {
+	testFixture := infratests.IntegrationTestFixture{
+		GoTest:                t,
+		TfOptions:             tests.AppGatewayOptions,
+		ExpectedTfOutputCount: 7,
+		TfOutputAssertions: []infratests.TerraformOutputValidation{
+			InspectAppGateway("resource_group_name", "appgateway_name", "keyvault_secret_id"),
+		},
+	}
+	infratests.RunIntegrationTests(&testFixture)
+}

--- a/infra/modules/providers/azure/app-gateway/tests/tf_options.go
+++ b/infra/modules/providers/azure/app-gateway/tests/tf_options.go
@@ -1,0 +1,32 @@
+//  Copyright © Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package tests
+
+import (
+	"os"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+// appGatewayName the name of the application gateway
+var appGatewayName = os.Getenv("APP_GATEWAY_NAME")
+
+var AppGatewayOptions = &terraform.Options{
+	TerraformDir: "../../",
+	Upgrade:      true,
+	Vars: map[string]interface{}{
+		"name": appGatewayName,
+	},
+}

--- a/infra/modules/providers/azure/app-gateway/variables.tf
+++ b/infra/modules/providers/azure/app-gateway/variables.tf
@@ -27,6 +27,11 @@ variable "appgateway_name" {
   type        = string
 }
 
+variable "location" {
+  description = "Location of the application gateway"
+  type        = string
+}
+
 variable "ssl_key_vault_secret_id" {
   description = "Secret Id of (base-64 encoded unencrypted pfx) Secret or Certificate object stored in Azure KeyVault. You need to enable soft delete for keyvault."
   type        = string

--- a/infra/modules/providers/azure/container-registry/tests/integration/acr.go
+++ b/infra/modules/providers/azure/container-registry/tests/integration/acr.go
@@ -1,0 +1,74 @@
+//  Copyright © Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/microsoft/cobalt/test-harness/infratests"
+	"github.com/microsoft/cobalt/test-harness/terratest-extensions/modules/azure"
+	"github.com/stretchr/testify/require"
+)
+
+// healthCheck - Asserts that the deployment was successful.
+func healthCheck(t *testing.T, provisionState string) {
+	require.Equal(t, "Succeeded", provisionState, "The deployment hasn't succeeded.")
+}
+
+// validateDeployment - Asserts that ACR deployment was successful
+func validateDeployment(
+	t *testing.T,
+	output infratests.TerraformOutput,
+	subscription_id string,
+	resource_group_name_output string,
+	container_registry_name_output string) {
+
+	// Obtain the container registry output name
+	acr_name := output[container_registry_name_output].(string)
+
+	// Obtain the registry structure
+	resource_group_name := output[resource_group_name_output].(string)
+
+	require.NotEmpty(t, resource_group_name, "Resource Group Name not returned.")
+	require.NotEmpty(t, acr_name, "Registry Name not returned.")
+
+	// Get Registry
+	registry, err := azure.ACRRegistryE(subscription_id, resource_group_name, acr_name)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get registry's properties
+	properties := registry.RegistryProperties
+	// check that the registry was provisioned
+	healthCheck(t, string(properties.ProvisioningState))
+
+	// check if the admin settings were disabled
+	isAdminEnabled := properties.AdminUserEnabled
+	require.Equal(t, false, *isAdminEnabled, "The admin user identity must be disabled for this registry.")
+
+}
+
+// InspectContainerRegistryOutputs - Runs test assertions to validate that the module outputs are valid.
+func InspectContainerRegistryOutputs(subscription_id string,
+	resource_group_name_output string,
+	container_registry_name_output string) func(t *testing.T, output infratests.TerraformOutput) {
+	return func(t *testing.T, output infratests.TerraformOutput) {
+		validateDeployment(t, output, subscription_id,
+			resource_group_name_output,
+			container_registry_name_output)
+	}
+}

--- a/infra/modules/providers/azure/container-registry/tests/integration/acr_test.go
+++ b/infra/modules/providers/azure/container-registry/tests/integration/acr_test.go
@@ -1,0 +1,44 @@
+//  Copyright © Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/microsoft/cobalt/infra/modules/providers/azure/container-registry/tests"
+	"github.com/microsoft/cobalt/test-harness/infratests"
+)
+
+const outputVariableCount int = 3
+
+var subscription_id = os.Getenv("ARM_SUBSCRIPTION_ID")
+
+func TestServiceDeployment(t *testing.T) {
+	if tests.name == "" {
+		t.Fatal(fmt.Errorf("Container Registry Name was not specified. Are all the required environment variables set?"))
+	}
+
+	testFixture := infratests.IntegrationTestFixture{
+		GoTest:                t,
+		TfOptions:             tests.StorageTFOptions,
+		ExpectedTfOutputCount: outputVariableCount,
+		TfOutputAssertions: []infratests.TerraformOutputValidation{
+			InspectContainerRegistryOutputs(subscription_id, "resource_group_name", "container_registry_name"),
+		},
+	}
+	infratests.RunIntegrationTests(&testFixture)
+}

--- a/infra/modules/providers/azure/cosmosdb/main.tf
+++ b/infra/modules/providers/azure/cosmosdb/main.tf
@@ -30,13 +30,8 @@ resource "azurerm_cosmosdb_account" "cosmosdb" {
   }
 
   geo_location {
-    location          = data.azurerm_resource_group.cosmosdb.location
-    failover_priority = 0
-  }
-
-  geo_location {
     location          = var.primary_replica_location
-    failover_priority = 1
+    failover_priority = 0
   }
 }
 

--- a/infra/modules/providers/azure/cosmosdb/main.tf
+++ b/infra/modules/providers/azure/cosmosdb/main.tf
@@ -30,8 +30,13 @@ resource "azurerm_cosmosdb_account" "cosmosdb" {
   }
 
   geo_location {
-    location          = var.primary_replica_location
+    location          = data.azurerm_resource_group.cosmosdb.location
     failover_priority = 0
+  }
+
+  geo_location {
+    location          = var.primary_replica_location
+    failover_priority = 1
   }
 }
 

--- a/infra/modules/providers/azure/cosmosdb/tests/integration/cosmos.go
+++ b/infra/modules/providers/azure/cosmosdb/tests/integration/cosmos.go
@@ -84,7 +84,7 @@ func InspectProvisionedCosmosDBAccount(resourceGroupOutputName, accountName, out
 		validateOfferType(t, result.DatabaseAccountOfferType)
 
 		failOverPolicies := *result.FailoverPolicies
-		require.Equal(t, 2, len(failOverPolicies))
+		require.Equal(t, 1, len(failOverPolicies))
 		validateFailOverPriority(t, failOverPolicies[0])
 
 		validateServiceResponse(t, output, outputName)

--- a/infra/modules/providers/azure/cosmosdb/tests/integration/cosmos.go
+++ b/infra/modules/providers/azure/cosmosdb/tests/integration/cosmos.go
@@ -84,7 +84,7 @@ func InspectProvisionedCosmosDBAccount(resourceGroupOutputName, accountName, out
 		validateOfferType(t, result.DatabaseAccountOfferType)
 
 		failOverPolicies := *result.FailoverPolicies
-		require.Equal(t, 1, len(failOverPolicies))
+		require.Equal(t, 2, len(failOverPolicies))
 		validateFailOverPriority(t, failOverPolicies[0])
 
 		validateServiceResponse(t, output, outputName)

--- a/infra/templates/osdu-r2-resources/.env.template
+++ b/infra/templates/osdu-r2-resources/.env.template
@@ -13,5 +13,6 @@ export TF_WARN_OUTPUT_ERRORS=1
 export TF_VAR_elasticsearch_username=
 export TF_VAR_elasticsearch_password=
 export TF_VAR_elasticsearch_endpoint=
+export TF_VAR_elasticsearch_version=
 export TF_VAR_cosmosdb_replica_location=
 export TF_VAR_resource_group_location=

--- a/infra/templates/osdu-r2-resources/commons.tf
+++ b/infra/templates/osdu-r2-resources/commons.tf
@@ -12,8 +12,20 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-module "provider" {
-  source = "../../modules/providers/azure/provider"
+provider "azurerm" {
+  version = "~>1.40.0"
+}
+
+provider "null" {
+  version = "~>2.1.0"
+}
+
+provider "azuread" {
+  version = "~>0.7.0"
+}
+
+provider "external" {
+  version = "~> 1.0"
 }
 
 data "azurerm_client_config" "current" {}

--- a/infra/templates/osdu-r2-resources/tests/integration/integration_test.go
+++ b/infra/templates/osdu-r2-resources/tests/integration/integration_test.go
@@ -39,7 +39,7 @@ var tfOptions = &terraform.Options{
 // Runs a suite of test assertions to validate that a provisioned set of app services
 // are fully funtional.
 func TestAppSvcPlanSingleRegion(t *testing.T) {
-	esIntegTestConfig.ESVersion = "6.8.3"
+	esIntegTestConfig.ESVersion = os.Getenv("TF_VAR_elasticsearch_version")
 	testFixture := infratests.IntegrationTestFixture{
 		GoTest:                t,
 		TfOptions:             tfOptions,

--- a/test-harness/terratest-extensions/modules/azure/acr.go
+++ b/test-harness/terratest-extensions/modules/azure/acr.go
@@ -16,8 +16,9 @@ package azure
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2017-10-01/containerregistry"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2017-10-01/containerregistry"
 )
 
 func registriesClientE(subscriptionID string) (*containerregistry.RegistriesClient, error) {
@@ -111,4 +112,20 @@ func ACRWebHookCallback(t *testing.T, subscriptionID string, resourceGroupName s
 		t.Fatal(err)
 	}
 	return webhookCallback
+}
+
+// ACRRegistryE - Return the Registry structure for the given ACR
+func ACRRegistryE(subscriptionID string, resourceGroupName string, acrName string) (*containerregistry.Registry, error) {
+
+	client, err := registriesClientE(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	acr, err := client.Get(context.Background(), resourceGroupName, acrName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &acr, nil
 }

--- a/test-harness/terratest-extensions/modules/azure/appgateway.go
+++ b/test-harness/terratest-extensions/modules/azure/appgateway.go
@@ -1,0 +1,58 @@
+//  Copyright © Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package azure
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-02-01/network"
+)
+
+func applicationGatewaysClientE(subscriptionID string) (*network.ApplicationGatewaysClient, error) {
+	authorizer, err := DeploymentServicePrincipalAuthorizer()
+	if err != nil {
+		return nil, err
+	}
+
+	client := network.NewApplicationGatewaysClient(subscriptionID)
+	client.Authorizer = authorizer
+	return &client, nil
+}
+
+func getAppGatewayPropertiesE(client *network.ApplicationGatewaysClient, resourceGroupName string, applicationGatewayName string) (*network.ApplicationGateway, error) { //?
+	ctx := context.Background()
+
+	applicationGateway, err := client.Get(ctx, resourceGroupName, applicationGatewayName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &applicationGateway, nil
+}
+
+// GetAppGatewayProperties - Get properties for an app gateway
+func GetAppGatewayProperties(subscription string, resourceGroupName string, appGatewayName string) (*network.ApplicationGateway, error) {
+	client, err := applicationGatewaysClientE(subscription)
+	if err != nil {
+		return nil, err
+	}
+
+	appGateway, err := getAppGatewayPropertiesE(client, resourceGroupName, appGatewayName)
+	if err != nil {
+		return nil, err
+	}
+
+	return appGateway, nil
+}


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [YES] All new and existing tests passed.

## Current Behavior or Linked Issues
-------------------------------------
This pull request prepares for working on AKS architecture changes, by updating modules with bug fixes needed for AKS, isolates terraform provider for OSDU R2 and extracts elastic version to a variable to allow for versions other then 6.8.3.



## Does this introduce a breaking change?
-------------------------------------
- [NO]



## Other information
-------------------------------------
This PR requires that a variable be added into the `Infrastructure Pipeline Variables -{env}` library.
TF_VAR_elasticsearch_version = 6.8.3
