### PR TITLE
Add the context path to the services: entitlement, legal, storage and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,10 @@ done
 | CONTAINER_REGISTRY_NAME | `$(ENVIRONMENT_STORAGE_PREFIX)cr` |
 | DEPLOY_ENV | `empty` |
 | DOMAIN | `contoso.com` |
-| ENTITLEMENT_URL | `https://$(AZURE_ENTITLEMENTS_SERVICE_NAME).azurewebsites.net/` |
+| ENTITLEMENT_URL | `https://$(AZURE_ENTITLEMENTS_SERVICE_NAME).azurewebsites.net/entitlements/v1/` |
 | EXPIRED_TOKEN |  |
 | FUNCTION_APP_NAME | `$(ENVIRONMENT_BASE_NAME_21)-enque` |
-| LEGAL_URL | `https://$(AZURE_LEGAL_SERVICE_NAME).azurewebsites.net/` |
+| LEGAL_URL | `https://$(AZURE_LEGAL_SERVICE_NAME).azurewebsites.net/api/legal/v1/` |
 | INTEGRATION_TESTER | `$(app-dev-sp-username)` |
 | MY_TENANT | `opendes` |
 | NO_DATA_ACCESS_TESTER | `$(osdu-infra-azg-test-app-noaccess-id)` |
@@ -317,7 +317,7 @@ done
 | RESOURCE_GROUP_NAME | `$(ENVIRONMENT_RG_PREFIX)-$(PREFIX_BASE)-app-rg` |
 | SEARCH_URL | `https://$(AZURE_SEARCH_SERVICE_NAME).azurewebsites.net/` |
 | SERVICE_CONNECTION_NAME| `osdu-infrastructure` |
-| STORAGE_URL | `https://$(AZURE_STORAGE_SERVICE_NAME).azurewebsites.net/` |
+| STORAGE_URL | `https://$(AZURE_STORAGE_SERVICE_NAME).azurewebsites.net/api/storage/v2/` |
 | _GOOGLE_CLOUD_PROJECT_ | _`opendes`_ |
 
 

--- a/docs/osdu/SERVICE_DEPLOYMENTS.md
+++ b/docs/osdu/SERVICE_DEPLOYMENTS.md
@@ -96,11 +96,11 @@ The following table describes the variable groups required to support this servi
 | `CONTAINER_REGISTRY_NAME` | `$(ENVIRONMENT_STORAGE_PREFIX)cr` | ACR name | no | ADO |
 | `DEPLOY_ENV` | `empty` | Deployment environment | no | ADO |
 | `DOMAIN` | `contoso.com` | Domain name | no | ADO |
-| `ENTITLEMENT_URL` | `https://$(AZURE_ENTITLEMENTS_SERVICE_NAME).azurewebsites.net/` | Entitlements endpoint | no | ADO |
+| `ENTITLEMENT_URL` | `https://$(AZURE_ENTITLEMENTS_SERVICE_NAME).azurewebsites.net/entitlements/v1/` | Entitlements endpoint | no | ADO |
 | `EXPIRED_TOKEN` | `********` | An expired JWT token | yes | ADO |
 | `FUNCTION_APP_NAME` | `$(ENVIRONMENT_BASE_NAME_21)-enque` | Name of App Service for enqueue function | no | ADO |
 | `INTEGRATION_TESTER` | `$(app-dev-sp-username)` | See `app-dev-sp-username` | yes | ADO |
-| `LEGAL_URL` | `https://$(AZURE_LEGAL_SERVICE_NAME).azurewebsites.net/` | Endpoint for legal service | no | ADO |
+| `LEGAL_URL` | `https://$(AZURE_LEGAL_SERVICE_NAME).azurewebsites.net/api/legal/v1/` | Endpoint for legal service | no | ADO |
 | `MY_TENANT` | `opendes` | OSDU tenant used for testing | no | ADO |
 | `NO_DATA_ACCESS_TESTER` | `$(aad-no-data-access-tester-client-id)` | See `aad-no-data-access-tester-client-id` | yes | ADO |
 | `NO_DATA_ACCESS_TESTER_SERVICEPRINCIPAL_SECRET` | `$(aad-no-data-access-tester-secret)` | See `aad-no-data-access-tester-secret` | yes | ADO |
@@ -108,7 +108,7 @@ The following table describes the variable groups required to support this servi
 | `PUBSUB_TOKEN` | `az` | . | no | ADO |
 | `RESOURCE_GROUP_NAME` | `$(ENVIRONMENT_RG_PREFIX)-$(PREFIX_BASE)-app-rg` | Resource group for deployments | no | ADO |
 | `SEARCH_URL` | `https://$(AZURE_SEARCH_SERVICE_NAME).azurewebsites.net/` | Endpoint for search service | no | ADO |
-| `STORAGE_URL` | `https://$(AZURE_STORAGE_SERVICE_NAME).azurewebsites.net/` | Endpoint of storage service | no | ADO |
+| `STORAGE_URL` | `https://$(AZURE_STORAGE_SERVICE_NAME).azurewebsites.net/api/storage/v2/` | Endpoint of storage service | no | ADO |
 | `VSTS_FEED_TOKEN` | `$(vsts-feed-token)` | See `vsts-feed-token` | yes | ADO |
 | `SERVICE_CONNECTION_NAME` | ex `cobalt-service-principal` | Default service connection name for deployment | no | ADO |
 

--- a/infra/templates/osdu-r2-resources/commons.tf
+++ b/infra/templates/osdu-r2-resources/commons.tf
@@ -93,10 +93,10 @@ locals {
   storage_app_name            = format("%s-%s", local.auth_svc_name_prefix, lower(local.storage_service_postfix))
   legal_app_name              = format("%s-%s", local.auth_svc_name_prefix, lower(local.legal_service_postfix))
   indexer_app_name            = format("%s-%s", local.auth_svc_name_prefix, lower(local.indexer_service_postfix))
-  entitlement_app_service_uri = format("https://%s-%s.azurewebsites.net", local.auth_svc_name_prefix, lower(local.entitlement_service_postfix))
-  legal_app_service_uri       = format("https://%s-%s.azurewebsites.net", local.auth_svc_name_prefix, lower(local.legal_service_postfix))
-  storage_app_service_uri     = format("https://%s-%s.azurewebsites.net", local.auth_svc_name_prefix, lower(local.storage_service_postfix))
-  indexer_app_service_uri     = format("https://%s-%s.azurewebsites.net", local.auth_svc_name_prefix, lower(local.indexer_service_postfix))
+  entitlement_app_service_uri = format("https://%s-%s.azurewebsites.net/entitlements/v1", local.auth_svc_name_prefix, lower(local.entitlement_service_postfix))
+  legal_app_service_uri       = format("https://%s-%s.azurewebsites.net/api/legal/v1", local.auth_svc_name_prefix, lower(local.legal_service_postfix))
+  storage_app_service_uri     = format("https://%s-%s.azurewebsites.net/api/storage/v2", local.auth_svc_name_prefix, lower(local.storage_service_postfix))
+  indexer_app_service_uri     = format("https://%s-%s.azurewebsites.net/api/indexer/v2", local.auth_svc_name_prefix, lower(local.indexer_service_postfix))
   graph_id                    = "00000003-0000-0000-c000-000000000000"      // ID for Microsoft Graph API
   graph_role_id               = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"      // ID for User.Read API
   elastic_search_name         = "${local.base_name_21}-es"                  // elastic search deployment


### PR DESCRIPTION
**Issue:**
Original services didn't have context path in the endpoint.

**Fix:**
Added context path to the services: entitlement, legal, storage and indexer. Context path added:

- Entitlement: entitlements/v1
- Legal: api/legal/v1
- Storage: api/storage/v2
- Indexer: api/indexer/v2 

**Dependencies:**
After applying this PR, services (entitlement, legal, storage, indexer) need to be updated. Please reference to Merge Requests created for the services in Gitlab.

**Is it a Breaking change?**
YES
As soon this PR is merged, services (entitlement, legal, storage, indexer) need to be updated to have reference to the new URL.
Environment variables need to be update as well. See below:

- ENTITLEMENT_URL: https://$(AZURE_ENTITLEMENTS_SERVICE_NAME).azurewebsites.net/entitlements/v1/
- LEGAL_URL: https://$(AZURE_LEGAL_SERVICE_NAME).azurewebsites.net/api/legal/v1/
- STORAGE_URL: https://$(AZURE_STORAGE_SERVICE_NAME).azurewebsites.net/api/storage/v2/

