### PR TITLE
Bring cosmos settings out to terraform.tfvars and allow for seperatio…

### DIFF
--- a/infra/templates/osdu-r2-resources/storage.tf
+++ b/infra/templates/osdu-r2-resources/storage.tf
@@ -12,46 +12,45 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-locals {
-  throughput = 400
-  cosmos_database = {
-    name       = local.cosmos_db_name
-    throughput = local.throughput
-  }
+# locals {
+#   cosmos_database = {
+#     name       = local.cosmos_db_name
+#     throughput = local.db_throughput
+#   }
 
-  cosmos_sql_collections = [
-    {
-      name               = "LegalTag"
-      database_name      = local.cosmos_db_name
-      partition_key_path = "/id"
-      throughput         = local.throughput
-    },
-    {
-      name               = "StorageRecord"
-      database_name      = local.cosmos_db_name
-      partition_key_path = "/id"
-      throughput         = local.throughput
-    },
-    {
-      name               = "StorageSchema"
-      database_name      = local.cosmos_db_name
-      partition_key_path = "/kind"
-      throughput         = local.throughput
-    },
-    {
-      name               = "TenantInfo"
-      database_name      = local.cosmos_db_name
-      partition_key_path = "/id"
-      throughput         = local.throughput
-    },
-    {
-      name               = "UserInfo"
-      database_name      = local.cosmos_db_name
-      partition_key_path = "/id"
-      throughput         = local.throughput
-    }
-  ]
-}
+#   cosmos_sql_collections = [
+#     {
+#       name               = "LegalTag"
+#       database_name      = local.cosmos_db_name
+#       partition_key_path = "/id"
+#       throughput         = local.col_throughput
+#     },
+#     {
+#       name               = "StorageRecord"
+#       database_name      = local.cosmos_db_name
+#       partition_key_path = "/id"
+#       throughput         = local.col_throughput
+#     },
+#     {
+#       name               = "StorageSchema"
+#       database_name      = local.cosmos_db_name
+#       partition_key_path = "/kind"
+#       throughput         = local.col_throughput
+#     },
+#     {
+#       name               = "TenantInfo"
+#       database_name      = local.cosmos_db_name
+#       partition_key_path = "/id"
+#       throughput         = local.col_throughput
+#     },
+#     {
+#       name               = "UserInfo"
+#       database_name      = local.cosmos_db_name
+#       partition_key_path = "/id"
+#       throughput         = local.col_throughput
+#     }
+#   ]
+# }
 
 module "storage_account" {
   source = "../../modules/providers/azure/storage-account"
@@ -76,6 +75,6 @@ module "cosmosdb_account" {
   primary_replica_location = var.cosmosdb_replica_location
   automatic_failover       = var.cosmosdb_automatic_failover
   consistency_level        = "Session"
-  databases                = [local.cosmos_database]
-  sql_collections          = local.cosmos_sql_collections
+  databases                = var.cosmos_databases
+  sql_collections          = var.cosmos_sql_collections
 }

--- a/infra/templates/osdu-r2-resources/terraform.tfvars
+++ b/infra/templates/osdu-r2-resources/terraform.tfvars
@@ -231,7 +231,7 @@ sb_topics = [
 cosmos_databases = [
   {
     name       = "dev-osdu-r2-db"
-    throughput = 1100
+    throughput = 400
   }
 ]
 

--- a/infra/templates/osdu-r2-resources/terraform.tfvars
+++ b/infra/templates/osdu-r2-resources/terraform.tfvars
@@ -228,6 +228,7 @@ sb_topics = [
   }
 ]
 
+# Database Settings
 cosmos_databases = [
   {
     name       = "dev-osdu-r2-db"

--- a/infra/templates/osdu-r2-resources/terraform.tfvars
+++ b/infra/templates/osdu-r2-resources/terraform.tfvars
@@ -227,3 +227,43 @@ sb_topics = [
     ]
   }
 ]
+
+cosmos_databases = [
+  {
+    name       = "dev-osdu-r2-db"
+    throughput = 1100
+  }
+]
+
+cosmos_sql_collections = [
+  {
+    name               = "LegalTag"
+    database_name      = "dev-osdu-r2-db"
+    partition_key_path = "/id"
+    throughput         = 400
+  },
+  {
+    name               = "StorageRecord"
+    database_name      = "dev-osdu-r2-db"
+    partition_key_path = "/id"
+    throughput         = 400
+  },
+  {
+    name               = "StorageSchema"
+    database_name      = "dev-osdu-r2-db"
+    partition_key_path = "/kind"
+    throughput         = 400
+  },
+  {
+    name               = "TenantInfo"
+    database_name      = "dev-osdu-r2-db"
+    partition_key_path = "/id"
+    throughput         = 400
+  },
+  {
+    name               = "UserInfo"
+    database_name      = "dev-osdu-r2-db"
+    partition_key_path = "/id"
+    throughput         = 400
+  }
+]


### PR DESCRIPTION
## All Submissions:
-------------------------------------?
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [NA] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [NA] All new and existing tests passed.

## Current Behavior or Linked Issues
-------------------------------------
Currently the throughput of the CosmosDB and collections within are set at 400 and are not adjustable.  

Example:
  Database Throughput: 1100
  Container 1: 400
  Container 2: 1100

This change brings up the cosmos settings into the terraform.tfvars where we have better control over the values.

## Does this introduce a breaking change?
-------------------------------------
- [NO]


## Other information
-------------------------------------
Right now this change doesn't allow us to have different settings for different environments so the change will also increase throughput of all environments of the database to 1100 due to new database work coming in a future release.
