### PR TITLE
passphrase is not stored in keyvault when calling install.sh twice

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -180,18 +180,19 @@ function CreateSSHKeys() {
     mkdir .ssh
   fi
 
-  if [ -f ./.ssh/$2 ]; then
+  if [ -f ./.ssh/$2.passphrase ]; then
     tput setaf 3;  echo "SSH Keys already exist."; tput sgr0
+    PASSPHRASE=`cat ./.ssh/${2}.passphrase`
   else
     cd .ssh
-
     PASSPHRASE=$(echo $((RANDOM%20000000000000000000+100000000000000000000)))
+    echo "$PASSPHRASE" >> "$2.passphrase"
     ssh-keygen -t rsa -b 2048 -C $1 -f $2 -N $PASSPHRASE && cd ..
-    AddKeyToVault $AZURE_VAULT "${2}-passphrase" $PASSPHRASE
   fi
 
   AddKeyToVault $AZURE_VAULT "${2}" ".ssh/${2}" "file"
   AddKeyToVault $AZURE_VAULT "${2}-pub" ".ssh/${2}.pub" "file"
+  AddKeyToVault $AZURE_VAULT "${2}-passphrase" $PASSPHRASE
 
  _result=`cat ./.ssh/${2}.pub`
  echo $_result

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -187,11 +187,11 @@ function CreateSSHKeys() {
 
     PASSPHRASE=$(echo $((RANDOM%20000000000000000000+100000000000000000000)))
     ssh-keygen -t rsa -b 2048 -C $1 -f $2 -N $PASSPHRASE && cd ..
+    AddKeyToVault $AZURE_VAULT "${2}-passphrase" $PASSPHRASE
   fi
 
   AddKeyToVault $AZURE_VAULT "${2}" ".ssh/${2}" "file"
   AddKeyToVault $AZURE_VAULT "${2}-pub" ".ssh/${2}.pub" "file"
-  AddKeyToVault $AZURE_VAULT "${2}-passphrase" $PASSPHRASE
 
  _result=`cat ./.ssh/${2}.pub`
  echo $_result


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [NA] All new and existing tests passed.

## Current Behavior or Linked Issues
-------------------------------------
This is a proposal for fixing issue #21
(interruption of the install.sh script when running it twice)


## Does this introduce a breaking change?
-------------------------------------
- [NO]

## Other information
-------------------------------------
The proposal is to store the PASSPHRASE variable in a file so that we can retreived it later.