### PR TITLE
Fix broken image links

### DIFF
--- a/infra/templates/osdu-r2-resources/README.md
+++ b/infra/templates/osdu-r2-resources/README.md
@@ -40,7 +40,7 @@ Cloud administrators that's versed with Cobalt templating.
 
 1. Azure Subscription
 2. An available Service Principal with API Permissions granted with Admin Consent within Azure app registration. The required Azure Active Directory Graph app role is `Application.ReadWrite.OwnedBy`
-![image](./docs/design/.design_images/TFPrincipal-Permissions.png)
+![image](./docs/images/TFPrincipal-Permissions.png)
 3. Terraform and Go are locally installed
 4. Azure Storage Account is [setup](https://docs.microsoft.com/en-us/azure/terraform/terraform-backend) to store Terraform state
 5. Local environment variables are [setup](https://github.com/Azure/osdu-infrastructure/blob/master/docs/osdu/INFRASTRUCTURE_DEPLOYMENTS.md)

--- a/infra/templates/osdu-r2-resources/docs/aks-environment.md
+++ b/infra/templates/osdu-r2-resources/docs/aks-environment.md
@@ -42,13 +42,13 @@ This document outlines how Cobalt can be extended to meet the use cases of these
 
 This graphic shows the targeted deployment topology needed by our enterprise customers. The deployment is deployed to a single tenant and subscription. The resources are partitioned to align with the different personas within the customer.
 
-![Deployment Topology](./.design_images/aks_deployment_topology.jpg "Deployment Topology")
+![Deployment Topology](./images/aks_deployment_topology.jpg "Deployment Topology")
 
 ## Template Topology
 
 The graphic below outlines the topology of the terraform templates that will deploy the topology called out above.
 
-![Template Topology](./.design_images/aks_template_topology.jpg "Template Topology")
+![Template Topology](./images/aks_template_topology.jpg "Template Topology")
 
 ## Terraform Template Environment Dependencies
 

--- a/infra/templates/osdu-r2-resources/docs/auth.md
+++ b/infra/templates/osdu-r2-resources/docs/auth.md
@@ -81,7 +81,7 @@ Considerations:
 
 
 # Proposal in image form
-![auth](.design_images/auth.png)
+![auth](images/auth.png)
 
 
 # Testing with MI
@@ -130,7 +130,7 @@ Impact of multi-tenancy in each of the core services:
 `os-storage`: The Record APIs check for a valid Tenant ID before allowing any modifications to Blob Storage or Cosmos.
 
 ## License
-Copyright © Microsoft Corporation
+Copyright ï¿½ Microsoft Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/infra/templates/osdu-r3-resources/environments/container_cluster/README.md
+++ b/infra/templates/osdu-r3-resources/environments/container_cluster/README.md
@@ -8,7 +8,7 @@ The `az-micro-svc-small-elastic-cloud` - `container_cluster` environment templat
 Template design [specifications](../../docs/design/aks-environment.md).
 
 ## Architecture
-![Template Topology](../../docs/design/.design_images/aks_deployment_topology.jpg "Template Topology")
+![Template Topology](../../docs/images/topology.png "Template Topology")
 
 ## Intended audience
 

--- a/infra/templates/osdu-r3-resources/environments/data_sources/README.md
+++ b/infra/templates/osdu-r3-resources/environments/data_sources/README.md
@@ -8,7 +8,7 @@ The `az-micro-svc-small-elastic-cloud` - `data_sources` environment template is 
 Template design [specifications](../../docs/design/README.md).
 
 ## Architecture
-![Template Topology](../../docs/design/.design_images/deployment_topology.jpg "Template Topology")
+![Template Topology](../../docs/images/topology.png "Template Topology")
 
 ## Intended audience
 

--- a/infra/templates/osdu-r3-resources/environments/image_repository/README.md
+++ b/infra/templates/osdu-r3-resources/environments/image_repository/README.md
@@ -8,7 +8,7 @@ The `az-micro-svc-small-elastic-cloud` - `image_registry` environment template i
 Template design [specifications](../../docs/design/README.md).
 
 ## Architecture
-![Template Topology](../../docs/design/.design_images/deployment_topology.jpg "Template Topology")
+![Template Topology](../../docs/images/topology.png "Template Topology")
 
 ## Intended audience
 


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [NA] All new and existing tests passed.

## Current Behavior or Linked Issues
-------------------------------------

Some markdown files contain broken image links.
ex: 
- the osdu-r2-resource template have a broken link for the TFPrincipal-Permissions.png
- osdu-r2-resource AKS does not show the deployment and template topology images
- osdu-r3-resources architecture topology is not shown for the image_repository, data_sources and container_cluster doccument


## Does this introduce a breaking change?
-------------------------------------
- [NO]

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
