### PR TITLE
Added Support for osdu pod identity to access secrets using CSI Secrets

### DIFF
--- a/infra/templates/osdu-r3-resources/environments/common_resources/main.tf
+++ b/infra/templates/osdu-r3-resources/environments/common_resources/main.tf
@@ -32,7 +32,7 @@ terraform {
 # Providers
 #-------------------------------
 provider "azurerm" {
-  version = "=2.16.0"
+  version = "=2.18.0"
   features {}
 }
 

--- a/infra/templates/osdu-r3-resources/environments/data_resources/main.tf
+++ b/infra/templates/osdu-r3-resources/environments/data_resources/main.tf
@@ -32,7 +32,7 @@ terraform {
 # Providers
 #-------------------------------
 provider "azurerm" {
-  version = "~> 2.8.0"
+  version = "~> 2.18.0"
   features {}
 }
 

--- a/infra/templates/osdu-r3-resources/environments/service_resources/tests/unit/unit_test.go
+++ b/infra/templates/osdu-r3-resources/environments/service_resources/tests/unit/unit_test.go
@@ -49,7 +49,7 @@ func TestTemplate(t *testing.T) {
 		TfOptions:                       tfOptions,
 		Workspace:                       workspace,
 		PlanAssertions:                  nil,
-		ExpectedResourceCount:           59,
+		ExpectedResourceCount:           61,
 		ExpectedResourceAttributeValues: resourceDescription,
 	}
 


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [YES] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] I have formatted the terrafrom code.  _(`terraform fmt -recursive && go fmt ./...`)_

## Current Behavior or Linked Issues
-------------------------------------
#78 

## Does this introduce a breaking change?
-------------------------------------
- [NO]


## Other information
-------------------------------------
The OSDU Identity didn't have the Managed Identity Operator Role for AKS and needed an access policy for KV applied to get secrets.
