### PR TITLE
Adding new Resources for WKS and Schema services

### DIFF
--- a/infra/templates/osdu-r3-resources/configurations/data_resources/terraform.tfvars
+++ b/infra/templates/osdu-r3-resources/configurations/data_resources/terraform.tfvars
@@ -17,7 +17,8 @@ prefix = "osdu-r3"
 # Storage Settings
 storage_containers = [
   "legal-service-azure-configuration",
-  "opendes"
+  "opendes",
+  "osdu-wks-mappings"
 ]
 
 # Database Settings
@@ -59,6 +60,30 @@ cosmos_sql_collections = [
     database_name      = "osdu-db"
     partition_key_path = "/id"
     throughput         = 400
+  },
+  {
+    name               = "Authority"
+    database_name      = "osdu-db"
+    partition_key_path = "/id"
+    throughput         = 400
+  },
+  {
+    name               = "EntityType"
+    database_name      = "osdu-db"
+    partition_key_path = "/id"
+    throughput         = 400
+  },
+  {
+    name               = "SchemaInfo"
+    database_name      = "osdu-db"
+    partition_key_path = "/id"
+    throughput         = 400
+  },
+  {
+    name               = "Source"
+    database_name      = "osdu-db"
+    partition_key_path = "/id"
+    throughput         = 400
   }
 ]
 
@@ -83,6 +108,16 @@ sb_topics = [
     subscriptions = [
       {
         name                                 = "recordstopicsubscription"
+        max_delivery_count                   = 5
+        lock_duration                        = "PT5M" //ISO 8601 format
+        forward_to                           = ""     //set with the topic name that will be used for forwarding. Otherwise, set to ""
+        dead_lettering_on_message_expiration = true
+        filter_type                          = null
+        sql_filter                           = null
+        action                               = ""
+      },
+      {
+        name                                 = "wkssubscription"
         max_delivery_count                   = 5
         lock_duration                        = "PT5M" //ISO 8601 format
         forward_to                           = ""     //set with the topic name that will be used for forwarding. Otherwise, set to ""


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES/NO] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES/NO] I have updated the documentation accordingly.
* [YES/NO/NA] I have added tests to cover my changes.
* [YES/NO/NA] All new and existing tests passed.
* [YES/NO/NA] I have formatted the terrafrom code.  _(`terraform fmt -recursive && go fmt ./...`)_

## Current Behavior or Linked Issues
-------------------------------------
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## Does this introduce a breaking change?
-------------------------------------
- [YES/NO]

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
-------------------------------------
Added new resources required for WKS and schema services
Resources added 
1. 4 Cosmos Db containers -> Authority, EntityType, SchemaInfo, Source
2. 1 Storage container -> osdu-wks-mappings
3. 1 service bus subscription -> wkssubscription on recordstopic

