### PR TITLE
Backout ServiceBus changes

### DIFF
--- a/infra/templates/osdu-r3-resources/configurations/data_resources/main.tf
+++ b/infra/templates/osdu-r3-resources/configurations/data_resources/main.tf
@@ -32,7 +32,7 @@ terraform {
 # Providers
 #-------------------------------
 provider "azurerm" {
-  version = "~> 2.18.0"
+  version = "~> 2.26.0"
   features {}
 }
 

--- a/infra/templates/osdu-r3-resources/configurations/data_resources/terraform.tfvars
+++ b/infra/templates/osdu-r3-resources/configurations/data_resources/terraform.tfvars
@@ -116,16 +116,6 @@ sb_topics = [
         sql_filter                           = null
         action                               = ""
       }
-      # {
-      #   name                                 = "wkssubscription"
-      #   max_delivery_count                   = 5
-      #   lock_duration                        = "PT5M" //ISO 8601 format
-      #   forward_to                           = ""     //set with the topic name that will be used for forwarding. Otherwise, set to ""
-      #   dead_lettering_on_message_expiration = true
-      #   filter_type                          = null
-      #   sql_filter                           = null
-      #   action                               = ""
-      # }
     ]
   },
   {

--- a/infra/templates/osdu-r3-resources/configurations/data_resources/tests/unit/servicebus.go
+++ b/infra/templates/osdu-r3-resources/configurations/data_resources/tests/unit/servicebus.go
@@ -26,11 +26,11 @@ func appendServicebusTests(t *testing.T, description infratests.ResourceDescript
 		"dead_lettering_on_message_expiration": true
 	}`)
 
-	// description["module.service_bus.azurerm_servicebus_subscription.subscription[5]"] = asMap(t, `{
-	// 	"name":                                 "indexing-progresssubscription",
-	// 	"dead_lettering_on_message_expiration": true,
-	// 	"max_delivery_count":                   5
-	// }`)
+	description["module.service_bus.azurerm_servicebus_subscription.subscription[4]"] = asMap(t, `{
+		"name":                                 "indexing-progresssubscription",
+		"dead_lettering_on_message_expiration": true,
+		"max_delivery_count":                   5
+	}`)
 
 	description["module.service_bus.azurerm_servicebus_topic.sptopic[0]"] = asMap(t, `{
 		"name":                         "recordstopic",


### PR DESCRIPTION
This PR is backing out the Service Bus change due to a bug where the configuration can not be deployed as a new instance.

The change will have to be reimplemented and tested again.

## Current Behavior or Linked Issues
-------------------------------------
#134 

