### PR TITLE
fixing the app name for schema service

### DIFF
--- a/devops/charts/osdu-common/templates/appgw-ingress.yaml
+++ b/devops/charts/osdu-common/templates/appgw-ingress.yaml
@@ -41,6 +41,6 @@ spec:
               servicePort: 80
             path: /api/search/v2/*
           - backend:
-              serviceName: schema
+              serviceName: schema-service
               servicePort: 80
             path: /api/schema-service/v1/*

--- a/devops/charts/osdu-istio-auth/templates/schema.yaml
+++ b/devops/charts/osdu-istio-auth/templates/schema.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-schema
+      app: schema-service
   action: DENY
   rules:
     - from:


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES/NO] Have you added an explanation of what your changes do and why you'd like us to include them? YES
* [YES/NO] I have updated the documentation accordingly. NA
* [YES/NO/NA] I have added tests to cover my changes. NA
* [YES/NO/NA] All new and existing tests passed. NA
* [YES/NO/NA] I have formatted the terrafrom code.  _(`terraform fmt -recursive && go fmt ./...`)_ NA

## Current Behavior or Linked Issues
-------------------------------------
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

fixing the app names for schema service in appgw-ingress file and istio config, so that it's consistent with the helm charts here:
https://community.opengroup.org/osdu/platform/system/schema-service/-/blob/master/devops/azure/chart/Chart.yaml

https://github.com/Azure/osdu-infrastructure/issues/134

## Does this introduce a breaking change?
-------------------------------------
- [YES/NO]
NO
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

cc: @polavishnu4444 , @danielscholl 