### PR TITLE
updating the partition key for schema service realted cosmos containers

### DIFF
--- a/infra/templates/osdu-r3-resources/configurations/data_resources/terraform.tfvars
+++ b/infra/templates/osdu-r3-resources/configurations/data_resources/terraform.tfvars
@@ -64,25 +64,25 @@ cosmos_sql_collections = [
   {
     name               = "Authority"
     database_name      = "osdu-db"
-    partition_key_path = "/id"
+    partition_key_path = "/dataPartitionId"
     throughput         = 400
   },
   {
     name               = "EntityType"
     database_name      = "osdu-db"
-    partition_key_path = "/id"
+    partition_key_path = "/dataPartitionId"
     throughput         = 400
   },
   {
     name               = "SchemaInfo"
     database_name      = "osdu-db"
-    partition_key_path = "/id"
+    partition_key_path = "/dataPartitionId"
     throughput         = 400
   },
   {
     name               = "Source"
     database_name      = "osdu-db"
-    partition_key_path = "/id"
+    partition_key_path = "/dataPartitionId"
     throughput         = 400
   }
 ]


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES/NO] Have you added an explanation of what your changes do and why you'd like us to include them? YES
* [YES/NO] I have updated the documentation accordingly. NA
* [YES/NO/NA] I have added tests to cover my changes. NA
* [YES/NO/NA] All new and existing tests passed. NA
* [YES/NO/NA] I have formatted the terraform code.  _(`terraform fmt -recursive && go fmt ./...`)_

## Current Behavior or Linked Issues
-------------------------------------
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There are four container required for schema service: `Authority`, `EntityType`, `SchemaInfo`, `Source`. All of these container are currently created with partition key as `id`, while the partition key should be `dataPartitionId`. fixing the same.
https://github.com/Azure/osdu-infrastructure/issues/134
## Does this introduce a breaking change?
-------------------------------------
- [YES/NO]

NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
cc: @danielscholl 