### PR TITLE
Updated Service Principal Module to support Bring Your Own

### DIFF
--- a/devops/infrastructure/pipeline-central.yml
+++ b/devops/infrastructure/pipeline-central.yml
@@ -27,8 +27,10 @@
 
 # Required Env Group Variables - `Infrastructure Pipeline - {configurations.jobName} - {env_name}`
   # TF_VAR_resource_group_location
-  # TF_VAR_cosmosdb_replica_location
-  
+  # TF_VAR_principal_appId
+  # TF_VAR_principal_name
+  # TF_VAR_principal_password
+  # TF_VAR_principal_objectId 
 
 
 # Deploy and validate infra changes once changes have been merged into

--- a/devops/infrastructure/tasks/tests-unit.yml
+++ b/devops/infrastructure/tasks/tests-unit.yml
@@ -43,6 +43,10 @@ steps:
       TF_VAR_ssh_public_key_file: $(aksPublicAgentKeySecureDownload.secureFilePath)
       TF_VAR_gitops_ssh_key_file: $(aksPrivateGitopsKeySecureDownload.secureFilePath)
       TF_VAR_gitops_ssh_url: $(TF_VAR_gitops_ssh_url)
+      TF_VAR_principal_appId: $(TF_VAR_principal_appId)
+      TF_VAR_principal_name: $(TF_VAR_principal_name)
+      TF_VAR_principal_password: $(TF_VAR_principal_password)
+      TF_VAR_principal_objectId: $(TF_VAR_principal_objectId)
 
     condition: not(coalesce(variables.SKIP_TESTS, ${{ parameters.skip }}))
     inputs:

--- a/devops/infrastructure/tasks/tf-plan.yml
+++ b/devops/infrastructure/tasks/tf-plan.yml
@@ -51,6 +51,10 @@ steps:
       TF_VAR_elasticsearch_username: $(elastic-username-${{ parameters.terraformWorkspacePrefix }}-${{ parameters.environmentName }})
       TF_VAR_elasticsearch_password: $(elastic-password-${{ parameters.terraformWorkspacePrefix }}-${{ parameters.environmentName }})
       TF_VAR_elasticsearch_endpoint: $(elastic-endpoint-${{ parameters.terraformWorkspacePrefix }}-${{ parameters.environmentName }})
+      TF_VAR_principal_appId: $(TF_VAR_principal_appId)
+      TF_VAR_principal_name: $(TF_VAR_principal_name)
+      TF_VAR_principal_password: $(TF_VAR_principal_password)
+      TF_VAR_principal_objectId: $(TF_VAR_principal_objectId)
 
     inputs:
       azureSubscription: '$(SERVICE_CONNECTION_NAME)'

--- a/infra/modules/magefile.go
+++ b/infra/modules/magefile.go
@@ -16,9 +16,6 @@ import (
 // A build step that runs all tests.
 func All() {
 	mg.Deps(TestModules)
-	mg.Deps(TestCommonResources)
-	mg.Deps(TestDataResources)
-	mg.Deps(TestServiceResources)
 }
 
 // Execute Module Tests and fail if a test fails. Only executes tests in 'test' directories.
@@ -27,66 +24,6 @@ func TestModules() error {
 	mg.Deps(Check)
 	fmt.Println("INFO: Running unit tests...")
 	return FindAndRunTests("testing")
-}
-
-// Execute Tests for R3 Common Resources.
-func TestCommonResources() {
-	mg.Deps(CommonUnitTest)
-	mg.Deps(CommonIntegrationTest)
-}
-
-// Execute Unit Tests for OSDU R3 Common Resources.
-func CommonUnitTest() error {
-	mg.Deps(Check)
-	fmt.Println("INFO: Running unit tests...")
-	return FindAndRunTests("common_resources/tests/unit")
-}
-
-// Execute Integration Tests for OSDU R3 Common Resources.
-func CommonIntegrationTest() error {
-	mg.Deps(Check)
-	fmt.Println("INFO: Running integration tests...")
-	return FindAndRunTests("common_resources/tests/integration")
-}
-
-// Execute Tests for R3 Data Resources.
-func TestDataResources() {
-	mg.Deps(DataUnitTest)
-	mg.Deps(DataIntegrationTest)
-}
-
-// Execute Unit Tests for OSDU R3 Data Resources.
-func DataUnitTest() error {
-	mg.Deps(Check)
-	fmt.Println("INFO: Running unit tests...")
-	return FindAndRunTests("data_resources/tests/unit")
-}
-
-// Execute Integration Tests for OSDU R3 Data Resources.
-func DataIntegrationTest() error {
-	mg.Deps(Check)
-	fmt.Println("INFO: Running integration tests...")
-	return FindAndRunTests("data_resources/tests/integration")
-}
-
-// Execute Tests for R3 Service Resources.
-func TestServiceResources() {
-	mg.Deps(ServiceUnitTest)
-	mg.Deps(ServiceIntegrationTest)
-}
-
-// Execute Unit Tests for OSDU R3 Service Resources.
-func ServiceUnitTest() error {
-	mg.Deps(Check)
-	fmt.Println("INFO: Running unit tests...")
-	return FindAndRunTests("service_resources/tests/unit")
-}
-
-// Execute Integration Tests for OSDU R3 Service Resources.
-func ServiceIntegrationTest() error {
-	mg.Deps(Check)
-	fmt.Println("INFO: Running integration tests...")
-	return FindAndRunTests("service_resources/tests/integration")
 }
 
 // Validate both Terraform code and Go code.

--- a/infra/modules/providers/azure/service-principal/main.tf
+++ b/infra/modules/providers/azure/service-principal/main.tf
@@ -13,7 +13,7 @@
 //  limitations under the License.
 
 resource "random_password" "main" {
-  count   = var.password == "" ? 1 : 0
+  count   = local.create_count != 0 && var.password != null ? 1 : 0
   length  = 32
   special = false
 }
@@ -60,7 +60,7 @@ resource "azurerm_role_assignment" "main" {
 }
 
 resource "azuread_service_principal_password" "main" {
-  count                = var.password != null ? 1 : 0
+  count                = local.create_count != 0 && var.password != null ? 1 : 0
   service_principal_id = azuread_service_principal.main[0].id
 
   value             = coalesce(var.password, random_password.main[0].result)

--- a/infra/modules/providers/azure/service-principal/output.tf
+++ b/infra/modules/providers/azure/service-principal/output.tf
@@ -14,21 +14,21 @@
 
 output "id" {
   description = "The ID of the Azure AD Service Principal"
-  value       = azuread_service_principal.main[0].object_id
-}
-
-output "client_id" {
-  description = "The ID of the Azure AD Application"
-  value       = azuread_service_principal.main[0].application_id
+  value       = var.create_for_rbac == true ? azuread_service_principal.main[0].object_id : var.object_id
 }
 
 output "name" {
   description = "The Display Name of the Azure AD Application associated with this Service Principal"
-  value       = azuread_service_principal.main[0].display_name
+  value       = var.create_for_rbac == true ? azuread_service_principal.main[0].display_name : var.principal.name
+}
+
+output "client_id" {
+  description = "The ID of the Azure AD Application"
+  value       = var.create_for_rbac == true ? azuread_service_principal.main[0].application_id : var.principal.appId
 }
 
 output "client_secret" {
   description = "The password of the generated service principal. This is only exported when create_for_rbac is true."
-  value       = azuread_service_principal_password.main[0].value
+  value       = var.create_for_rbac == true ? azuread_service_principal_password.main[0].value : var.principal.password
   sensitive   = true
 }

--- a/infra/modules/providers/azure/service-principal/sample/main.tf
+++ b/infra/modules/providers/azure/service-principal/sample/main.tf
@@ -40,21 +40,60 @@ resource "azurerm_resource_group" "main" {
   location = local.location
 }
 
+# This Example Creates a Service Principal
+# module "service_principal" {
+#   source = "../"
+
+#   name     = format("${local.name}-%s-ad-app-management", random_id.main.hex)
+#   role     = "Contributor"
+#   scopes   = [azurerm_resource_group.main.id]
+#   end_date = "1W"
+
+#   api_permissions = [
+#     {
+#       name = "Microsoft Graph"
+#       app_roles = [
+#         "User.Read.All",
+#         "Directory.Read.All"
+#       ]
+#     }
+#   ]
+# }
+
+# This Example Uses an Existing Service Principal
 module "service_principal" {
   source = "../"
 
-  name     = format("${local.name}-%s-ad-app-management", random_id.main.hex)
-  role     = "Contributor"
-  scopes   = [azurerm_resource_group.main.id]
-  end_date = "1W"
+  name   = "iac-osdu-246-ad-app-management"
+  scopes = [azurerm_resource_group.main.id]
+  role   = "Contributor"
 
-  api_permissions = [
-    {
-      name = "Microsoft Graph"
-      app_roles = [
-        "Directory.Read.All"
-      ]
-    }
-  ]
+  create_for_rbac = false
+  object_id       = "1586d1ed-dd0b-45ce-a698-f155a7becc8b"
 
+  principal = {
+    name     = "iac-osdu-246-ad-app-management"
+    appId    = "2357b068-2541-4244-8866-27e23aa0a112"
+    password = "******************************"
+  }
+}
+
+output "id" {
+  description = "The ID of the Azure AD Service Principal"
+  value       = module.service_principal.id
+}
+
+output "name" {
+  description = "The Display Name of the Azure AD Application associated with this Service Principal"
+  value       = module.service_principal.name
+}
+
+output "client_id" {
+  description = "The ID of the Azure AD Application"
+  value       = module.service_principal.client_id
+}
+
+output "client_secret" {
+  description = "The password of the generated service principal. This is only exported when create_for_rbac is true."
+  value       = module.service_principal.client_secret
 }

--- a/infra/modules/providers/azure/service-principal/sample/unit_test.go
+++ b/infra/modules/providers/azure/service-principal/sample/unit_test.go
@@ -47,11 +47,8 @@ func TestTemplate(t *testing.T) {
 		"required_resource_access": [{
 			"resource_app_id": "00000003-0000-0000-c000-000000000000",
 			"resource_access": [{
-				"id": "06da0dbc-49e2-44d2-8312-53f166ab848a",
-				"type": "Scope"
-			}, {
-				"id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
-				"type": "Scope"
+				"id": "df021288-bdef-4463-88db-98f22de89214",
+				"type": "Role"
 			}, {
 				"id": "7ab1d382-f21e-4acd-a863-ba3e13f7da61",
 				"type": "Role"

--- a/infra/modules/providers/azure/service-principal/variables.tf
+++ b/infra/modules/providers/azure/service-principal/variables.tf
@@ -48,10 +48,17 @@ variable "create_for_rbac" {
 }
 
 variable "object_id" {
-  description = "Object Id of an existing service principle to be assigned to a role."
+  description = "Object Id of an existing AD app to be assigned to a role."
   type        = string
   default     = ""
 }
+
+variable "principal" {
+  description = "Bring your own Principal metainformation. Optional: {name, appId, password}"
+  type        = map(string)
+  default     = {}
+}
+
 
 variable "api_permissions" {
   type        = any

--- a/infra/templates/osdu-r3-mvp/central_resources/README.md
+++ b/infra/templates/osdu-r3-mvp/central_resources/README.md
@@ -6,6 +6,46 @@ __PreRequisites__
 
 Requires the use of [direnv](https://direnv.net/) for environment variable management.
 
+Requires a preexisting Service Principal to be created to be used for this OSDU Environment.
+
+```bash
+ENV=$USER  # This is helpful to set to your expected OSDU environment name.
+NAME="osdu-mvp-$ENV-principal"
+
+# Create a Service Principal
+az ad sp create-for-rbac --name $NAME --skip-assignment -ojson
+
+# Result
+{
+  "appId": "<guid>",                # -> Use this for TF_VAR_principal_appId
+  "displayName": "<name>",          # -> Use this for TF_VAR_principal_name
+  "name": "http://<name>",
+  "password": "****************",   # -> Use this for TF_VAR_principal_password
+  "tenant": "<ad_tenant>"
+}
+
+# Retrieve the AD Application Metadata Information
+az ad sp list --display-name $NAME --query [].objectId -ojson
+
+# Result
+[
+  "<guid>"                          # -> Use this for TF_VAR_principal_objectId
+]
+
+
+# Assign API Permissions
+# Microsoft Graph -- Application Permissions -- Directory.Read.All  ** GRANT ADMIN-CONSENT
+adObjectId=$(az ad app list --display-name $NAME --query [].objectId -otsv)
+graphId=$(az ad sp list --query "[?appDisplayName=='Microsoft Graph'].appId | [0]" --all -otsv)
+directoryReadAll=$(az ad sp show --id $graphId --query "appRoles[?value=='Directory.Read.All'].id | [0]" -otsv)=Role
+
+az ad app permission add --id $adObjectId --api $graphId --api-permissions $directoryReadAll
+
+# Grant Admin Consent
+# ** REQUIRES ADMIN AD ACCESS **
+az ad app permission admin-consent --id $appId 
+```
+
 ## Deployment Steps
 
 1. Set up your local environment variables

--- a/infra/templates/osdu-r3-mvp/central_resources/tests/unit/unit_test.go
+++ b/infra/templates/osdu-r3-mvp/central_resources/tests/unit/unit_test.go
@@ -49,7 +49,7 @@ func TestTemplate(t *testing.T) {
 		TfOptions:                       tfOptions,
 		Workspace:                       workspace,
 		PlanAssertions:                  nil,
-		ExpectedResourceCount:           26,
+		ExpectedResourceCount:           34,
 		ExpectedResourceAttributeValues: resourceDescription,
 	}
 

--- a/infra/templates/osdu-r3-resources/magefile.go
+++ b/infra/templates/osdu-r3-resources/magefile.go
@@ -1,0 +1,140 @@
+//+build mage
+
+// osdu-infrastructure task runner.
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+)
+
+// A build step that runs all tests.
+func All() {
+	mg.Deps(TestCommonResources)
+	mg.Deps(TestDataResources)
+	mg.Deps(TestServiceResources)
+}
+
+// Execute Tests for R3 Common Resources.
+func TestCommonResources() {
+	mg.Deps(CommonUnitTest)
+	mg.Deps(CommonIntegrationTest)
+}
+
+// Execute Unit Tests for OSDU R3 Common Resources.
+func CommonUnitTest() error {
+	mg.Deps(Check)
+	fmt.Println("INFO: Running unit tests...")
+	return FindAndRunTests("common_resources/tests/unit")
+}
+
+// Execute Integration Tests for OSDU R3 Common Resources.
+func CommonIntegrationTest() error {
+	mg.Deps(Check)
+	fmt.Println("INFO: Running integration tests...")
+	return FindAndRunTests("common_resources/tests/integration")
+}
+
+// Execute Tests for R3 Data Resources.
+func TestDataResources() {
+	mg.Deps(DataUnitTest)
+	mg.Deps(DataIntegrationTest)
+}
+
+// Execute Unit Tests for OSDU R3 Data Resources.
+func DataUnitTest() error {
+	mg.Deps(Check)
+	fmt.Println("INFO: Running unit tests...")
+	return FindAndRunTests("data_resources/tests/unit")
+}
+
+// Execute Integration Tests for OSDU R3 Data Resources.
+func DataIntegrationTest() error {
+	mg.Deps(Check)
+	fmt.Println("INFO: Running integration tests...")
+	return FindAndRunTests("data_resources/tests/integration")
+}
+
+// Execute Tests for R3 Service Resources.
+func TestServiceResources() {
+	mg.Deps(ServiceUnitTest)
+	mg.Deps(ServiceIntegrationTest)
+}
+
+// Execute Unit Tests for OSDU R3 Service Resources.
+func ServiceUnitTest() error {
+	mg.Deps(Check)
+	fmt.Println("INFO: Running unit tests...")
+	return FindAndRunTests("service_resources/tests/unit")
+}
+
+// Execute Integration Tests for OSDU R3 Service Resources.
+func ServiceIntegrationTest() error {
+	mg.Deps(Check)
+	fmt.Println("INFO: Running integration tests...")
+	return FindAndRunTests("service_resources/tests/integration")
+}
+
+// Validate both Terraform code and Go code.
+func Check() {
+	mg.Deps(LintTF)
+	mg.Deps(LintGO)
+}
+
+// Lint check Go and fail if files are not not formatted properly.
+func LintGO() error {
+	fmt.Println("INFO: Checking format for Go files...")
+	return verifyRunsQuietly("Run `go fmt ./...` to fix", "go", "fmt", "./...")
+}
+
+// Lint check Terraform and fail if files are not formatted properly.
+func LintTF() error {
+	fmt.Println("INFO: Checking format for Terraform files...")
+	return verifyRunsQuietly("Run `terraform fmt --check --recursive` to fix the offending files", "terraform", "fmt")
+}
+
+//-------------------------------
+// GO UTILITY FUNCTIONS
+//-------------------------------
+
+// runs a command and ensures that the exit code indicates success and that there is no output to stdout
+func verifyRunsQuietly(instructionsToFix string, cmd string, args ...string) error {
+	output, err := sh.Output(cmd, args...)
+
+	if err != nil {
+		return err
+	}
+
+	if len(output) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("ERROR: command '%s' with arguments %s failed. Output was: '%s'. %s", cmd, args, output, instructionsToFix)
+}
+
+// FindAndRunTests finds all tests with a given path suffix and runs them using `go test`
+func FindAndRunTests(pathSuffix string) error {
+	goModules, err := sh.Output("go", "list", "./...")
+	if err != nil {
+		return err
+	}
+
+	testTargetModules := make([]string, 0)
+	for _, module := range strings.Fields(goModules) {
+		if strings.HasSuffix(module, pathSuffix) {
+			testTargetModules = append(testTargetModules, module)
+		}
+	}
+
+	if len(testTargetModules) == 0 {
+		return fmt.Errorf("No modules found for testing prefix '%s'", pathSuffix)
+	}
+
+	cmdArgs := []string{"test"}
+	cmdArgs = append(cmdArgs, testTargetModules...)
+	cmdArgs = append(cmdArgs, "-v", "-timeout", "7200s")
+	return sh.RunV("go", cmdArgs...)
+}


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [YES] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] I have formatted the terraform code.  _(`terraform fmt -recursive && go fmt ./...`)_

## Current Behavior or Linked Issues
-------------------------------------
This change is implementing a module change for service principal that allows backward compatibility of creating service principals but allow a customer to bring their own service principal.

The benefit of this is that if you bring your own service principal the terraform service principal does not need elevated permissions.


## Does this introduce a breaking change?
-------------------------------------
- [NO]

