### PR TITLE
Adding service-entitlements-admin group to TenantInfo

### DIFF
--- a/docs/osdu/integration-test-data/tenant_info_1.json
+++ b/docs/osdu/integration-test-data/tenant_info_1.json
@@ -15,6 +15,7 @@
     "data.default.viewers",
     "data.default.owners",
     "service.schema-service.viewers",
-    "service.schema-service.editors"
+    "service.schema-service.editors",
+    "service.entitlements.admin"
   ]
 }

--- a/docs/osdu/integration-test-data/tenant_info_2.json
+++ b/docs/osdu/integration-test-data/tenant_info_2.json
@@ -14,6 +14,7 @@
     "data.default.viewers",
     "data.default.owners",
     "service.schema-service.viewers",
-    "service.schema-service.editors"
+    "service.schema-service.editors",
+    "service.entitlements.admin"
   ]
 }


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES/NO] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES/NO] I have updated the documentation accordingly.
* [YES/NO/NA] I have added tests to cover my changes.
* [YES/NO/NA] All new and existing tests passed.
* [YES/NO/NA] I have formatted the terraform code.  _(`terraform fmt -recursive && go fmt ./...`)_

## Current Behavior or Linked Issues
-------------------------------------
service.entitlements.admin group was missing from TenantInfo collection'
TenantInfo should contain all the groups


## Does this introduce a breaking change?
-------------------------------------
- [YES/NO]

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
