### PR TITLE
Network Changes and AKS Version Change

### DIFF
--- a/devops/infrastructure/pipeline-partition.yml
+++ b/devops/infrastructure/pipeline-partition.yml
@@ -92,8 +92,3 @@ stages:
       terraformTemplatePath: infra/templates/osdu-r3-mvp/data_partition
       deploymentTimeoutInMinutes: 120
       dataPartitionName: opendes
-    - jobName: data_partition_2
-      terraformWorkspacePrefix: dp2
-      terraformTemplatePath: infra/templates/osdu-r3-mvp/data_partition
-      deploymentTimeoutInMinutes: 120
-      dataPartitionName: common

--- a/infra/modules/providers/azure/aks-appgw/main.tf
+++ b/infra/modules/providers/azure/aks-appgw/main.tf
@@ -79,7 +79,7 @@ resource "azurerm_application_gateway" "main" {
   }
 
   waf_configuration {
-    enabled          = var.tier == "WAF" ? true : false
+    enabled          = var.tier == "WAF" || var.tier == "WAF_v2" ? true : false
     firewall_mode    = var.waf_config_firewall_mode
     rule_set_type    = "OWASP"
     rule_set_version = "3.1"

--- a/infra/modules/providers/azure/aks-appgw/variables.tf
+++ b/infra/modules/providers/azure/aks-appgw/variables.tf
@@ -44,7 +44,7 @@ variable "tier" {
 variable "waf_config_firewall_mode" {
   description = "The firewall mode on the waf gateway"
   type        = string
-  default     = "Prevention"
+  default     = "Detection"
 }
 
 variable "vnet_name" {

--- a/infra/modules/providers/azure/network/main.tf
+++ b/infra/modules/providers/azure/network/main.tf
@@ -26,9 +26,12 @@ resource "azurerm_virtual_network" "main" {
 }
 
 resource "azurerm_subnet" "main" {
+  count = length(var.subnet_names)
+
   name                 = var.subnet_names[count.index]
   virtual_network_name = azurerm_virtual_network.main.name
   resource_group_name  = data.azurerm_resource_group.main.name
   address_prefixes     = [var.subnet_prefixes[count.index]]
-  count                = length(var.subnet_names)
+  service_endpoints    = lookup(var.subnet_service_endpoints, var.subnet_names[count.index], null)
 }
+

--- a/infra/modules/providers/azure/network/variables.tf
+++ b/infra/modules/providers/azure/network/variables.tf
@@ -52,3 +52,9 @@ variable "subnet_names" {
   description = "A list of public subnets inside the vNet."
   default     = ["subnet1"]
 }
+
+variable "subnet_service_endpoints" {
+  description = "A map of subnet name to service endpoints to add to the subnet."
+  type        = map(any)
+  default     = {}
+}

--- a/infra/templates/osdu-r3-mvp/service_resources/main.tf
+++ b/infra/templates/osdu-r3-mvp/service_resources/main.tf
@@ -261,8 +261,16 @@ module "network" {
   name                = local.vnet_name
   resource_group_name = azurerm_resource_group.main.name
   address_space       = var.address_space
-  subnet_prefixes     = [var.subnet_fe_prefix, var.subnet_aks_prefix, var.subnet_be_prefix]
-  subnet_names        = [local.fe_subnet_name, local.aks_subnet_name, local.be_subnet_name]
+  subnet_prefixes     = [var.subnet_fe_prefix, var.subnet_aks_prefix]
+  subnet_names        = [local.fe_subnet_name, local.aks_subnet_name]
+  subnet_service_endpoints = {
+    (local.aks_subnet_name) = ["Microsoft.Storage",
+      "Microsoft.Sql",
+      "Microsoft.AzureCosmosDB",
+      "Microsoft.KeyVault",
+      "Microsoft.ServiceBus",
+    "Microsoft.EventHub"]
+  }
 
   resource_tags = var.resource_tags
 }

--- a/infra/templates/osdu-r3-mvp/service_resources/tests/unit/unit_test.go
+++ b/infra/templates/osdu-r3-mvp/service_resources/tests/unit/unit_test.go
@@ -49,7 +49,7 @@ func TestTemplate(t *testing.T) {
 		TfOptions:                       tfOptions,
 		Workspace:                       workspace,
 		PlanAssertions:                  nil,
-		ExpectedResourceCount:           82,
+		ExpectedResourceCount:           81,
 		ExpectedResourceAttributeValues: resourceDescription,
 	}
 

--- a/infra/templates/osdu-r3-mvp/service_resources/variables.tf
+++ b/infra/templates/osdu-r3-mvp/service_resources/variables.tf
@@ -204,7 +204,7 @@ variable "aks_agent_vm_size" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.17.7"
+  default = "1.17.11"
 }
 
 variable "ssh_public_key_file" {


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [YES] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] I have formatted the terraform code.  _(`terraform fmt -recursive && go fmt ./...`)_

## Current Behavior or Linked Issues
-------------------------------------
Removed Backend Subnet.
Added Service Endpoints for services to AKS Subnet
Enabled WAF on Gateway with detection mode.
Updated Default Kubernetes version.


## Does this introduce a breaking change?
-------------------------------------
- [Yes]

This may break App Gateway with a conflict due to AKS ingress already having a certificate in place.
It also may destroy AKS due to the version change.
