### PR TITLE
gitops_path variable added

### DIFF
--- a/devops/infrastructure/tasks/tests-unit.yml
+++ b/devops/infrastructure/tasks/tests-unit.yml
@@ -47,6 +47,7 @@ steps:
       TF_VAR_principal_name: $(TF_VAR_principal_name)
       TF_VAR_principal_password: $(TF_VAR_principal_password)
       TF_VAR_principal_objectId: $(TF_VAR_principal_objectId)
+      TF_VAR_gitops_path: $(TF_VAR_gitops_path)
 
     condition: not(coalesce(variables.SKIP_TESTS, ${{ parameters.skip }}))
     inputs:

--- a/devops/infrastructure/tasks/tf-plan.yml
+++ b/devops/infrastructure/tasks/tf-plan.yml
@@ -55,6 +55,7 @@ steps:
       TF_VAR_principal_name: $(TF_VAR_principal_name)
       TF_VAR_principal_password: $(TF_VAR_principal_password)
       TF_VAR_principal_objectId: $(TF_VAR_principal_objectId)
+      TF_VAR_gitops_path: $(TF_VAR_gitops_path)
 
     inputs:
       azureSubscription: '$(SERVICE_CONNECTION_NAME)'


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [NO] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [NA] All new and existing tests passed.
* [NA] I have formatted the terraform code.  _(`terraform fmt -recursive && go fmt ./...`)_

## Current Behavior or Linked Issues
-------------------------------------
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
[Issue #185](https://github.com/Azure/osdu-infrastructure/issues/185)

## Does this introduce a breaking change?
-------------------------------------
- [NO]

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
`gitops_path` variable has been added to the `tests-unit.yml` and `tf-plan.yml` files to take values from the pipeline. Before that it used the [default value](https://github.com/Azure/osdu-infrastructure/blob/master/infra/templates/osdu-r3-mvp/service_resources/variables.tf#L237-L241) and as a result Flux could not use the same repo for the setup of different environments