### PR TITLE
Updating mvp byosp documentation

### DIFF
--- a/infra/modules/providers/azure/service-principal/variables.tf
+++ b/infra/modules/providers/azure/service-principal/variables.tf
@@ -48,7 +48,7 @@ variable "create_for_rbac" {
 }
 
 variable "object_id" {
-  description = "Object Id of an existing AD app to be assigned to a role."
+  description = "Object Id of an existing AD service principal to be assigned to a role."
   type        = string
   default     = ""
 }

--- a/infra/templates/osdu-r3-mvp/central_resources/README.md
+++ b/infra/templates/osdu-r3-mvp/central_resources/README.md
@@ -25,7 +25,7 @@ az ad sp create-for-rbac --name $NAME --skip-assignment -ojson
 }
 
 # Retrieve the AD Application Metadata Information
-az ad app list --display-name $NAME --query [].objectId -ojson
+az ad sp list --display-name $NAME --query [].objectId -ojson
 
 # Result
 [

--- a/infra/templates/osdu-r3-mvp/central_resources/README.md
+++ b/infra/templates/osdu-r3-mvp/central_resources/README.md
@@ -24,7 +24,7 @@ az ad sp create-for-rbac --name $NAME --skip-assignment -ojson
   "tenant": "<ad_tenant>"
 }
 
-# Retrieve the AD Application Metadata Information
+# Retrieve the AD Service Pricipal ID
 az ad sp list --display-name $NAME --query [].objectId -ojson
 
 # Result


### PR DESCRIPTION
Updating documentation to clarify which object id to pass in to terraform. There is now agreement between the central resources README, sp provider README, sp provider variables.tf, and sp provider output.tf that you need to be passing in the sp object id, not the app object id.

## All Submissions:
-------------------------------------
* [YES/NO] Have you added an explanation of what your changes do and why you'd like us to include them? YES see above
* [YES/NO] I have updated the documentation accordingly. YES only documentation changes
* [YES/NO/NA] I have added tests to cover my changes. NA
* [YES/NO/NA] All new and existing tests passed. NA
* [YES/NO/NA] I have formatted the terraform code.  _(`terraform fmt -recursive && go fmt ./...`)_ NA

## Current Behavior or Linked Issues
-------------------------------------
Fixing documentation for clarity, no issue to track with.


## Does this introduce a breaking change?
-------------------------------------
- [YES/NO]

NO

## Other information
-------------------------------------
NA
