### PR TITLE
changing k8s version in service_resources to 1.17.11

### DIFF
--- a/infra/templates/osdu-r3-resources/configurations/service_resources/var.tf
+++ b/infra/templates/osdu-r3-resources/configurations/service_resources/var.tf
@@ -104,7 +104,7 @@ variable "aks_agent_vm_size" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.17.7"
+  default = "1.17.11"
 }
 
 variable "flux_recreate" {


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES/NO] Have you added an explanation of what your changes do and why you'd like us to include them? release/3.0-beta branch cannot deploy right now because its kubernetes version is not supported by aks. This PR updates that version
* [YES/NO] I have updated the documentation accordingly. NA
* [YES/NO/NA] I have added tests to cover my changes. NA
* [YES/NO/NA] All new and existing tests passed. YES (ran sr unit and integration tests)
* [YES/NO/NA] I have formatted the terraform code.  _(`terraform fmt -recursive && go fmt ./...`)_ NA

## Current Behavior or Linked Issues
-------------------------------------
Getting this error when deploying:
Error: creating Managed Kubernetes Cluster "osdu-r3-jasonsan-zvr3-aks" (Resource Group "osdu-r3-jasonsansr-zvr3-rg"): containerservice.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="AgentPoolK8sVersionNotSupported" Message="Version 1.17.7 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list"

## Does this introduce a breaking change?
-------------------------------------
- [YES/NO]

NO

## Other information
-------------------------------------
NA