### PR TITLE
Additional roles added for the Storage Accounts.

### DIFF
--- a/infra/templates/osdu-r3-mvp/data_partition/main.tf
+++ b/infra/templates/osdu-r3-mvp/data_partition/main.tf
@@ -168,6 +168,15 @@ resource "azurerm_role_assignment" "storage_access" {
   scope                = module.storage_account.id
 }
 
+// Add Data Contributor Role to Principal
+resource "azurerm_role_assignment" "storage_access" {
+  count = length(local.rbac_principals)
+
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = local.rbac_principals[count.index]
+  scope                = module.storage_account.id
+}
+
 module "sdms_storage_account" {
   source = "../../../modules/providers/azure/storage-account"
 
@@ -189,6 +198,14 @@ resource "azurerm_role_assignment" "sdms_storage_access" {
   scope                = module.sdms_storage_account.id
 }
 
+// Add Data Contributor Role to Principal
+resource "azurerm_role_assignment" "storage_access" {
+  count = length(local.rbac_principals)
+
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = local.rbac_principals[count.index]
+  scope                = module.sdms_storage_account.id
+}
 
 #-------------------------------
 # CosmosDB

--- a/infra/templates/osdu-r3-mvp/data_partition/main.tf
+++ b/infra/templates/osdu-r3-mvp/data_partition/main.tf
@@ -169,7 +169,7 @@ resource "azurerm_role_assignment" "storage_access" {
 }
 
 // Add Data Contributor Role to Principal
-resource "azurerm_role_assignment" "storage_access" {
+resource "azurerm_role_assignment" "storage_data_contributor" {
   count = length(local.rbac_principals)
 
   role_definition_name = "Storage Blob Data Contributor"
@@ -199,7 +199,7 @@ resource "azurerm_role_assignment" "sdms_storage_access" {
 }
 
 // Add Data Contributor Role to Principal
-resource "azurerm_role_assignment" "storage_access" {
+resource "azurerm_role_assignment" "sdms_storage_data_contributor" {
   count = length(local.rbac_principals)
 
   role_definition_name = "Storage Blob Data Contributor"

--- a/infra/templates/osdu-r3-mvp/data_partition/tests/unit/unit_test.go
+++ b/infra/templates/osdu-r3-mvp/data_partition/tests/unit/unit_test.go
@@ -49,7 +49,7 @@ func TestTemplate(t *testing.T) {
 		TfOptions:                       tfOptions,
 		Workspace:                       workspace,
 		PlanAssertions:                  nil,
-		ExpectedResourceCount:           75,
+		ExpectedResourceCount:           79,
 		ExpectedResourceAttributeValues: resourceDescription,
 	}
 


### PR DESCRIPTION
- Added additional `Storage Blob Data Contributor` role added to both the Storage Accounts for the service principals.

## All Submissions:
-------------------------------------
* [YES/NO] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES/NO] I have updated the documentation accordingly.
* [YES/NO/NA] I have added tests to cover my changes.
* [YES/NO/NA] All new and existing tests passed.
* [YES/NO/NA] I have formatted the terraform code.  _(`terraform fmt -recursive && go fmt ./...`)_

## Current Behavior or Linked Issues
-------------------------------------
Currently without this role the test gets a 403 access error and fails for the Legal Service tests.


## Does this introduce a breaking change?
-------------------------------------
- [NO]

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
