### PR TITLE
Updated Chart versions

### DIFF
--- a/infra/templates/osdu-r3-mvp/service_resources/helm_keda.tf
+++ b/infra/templates/osdu-r3-mvp/service_resources/helm_keda.tf
@@ -20,7 +20,7 @@ locals {
   helm_keda_name    = "keda"
   helm_keda_ns      = "keda"
   helm_keda_repo    = "https://kedacore.github.io/charts"
-  helm_keda_version = "1.4"
+  helm_keda_version = "1.4.2"
 }
 
 resource "kubernetes_namespace" "keda" {

--- a/infra/templates/osdu-r3-mvp/service_resources/helm_kv_csi.tf
+++ b/infra/templates/osdu-r3-mvp/service_resources/helm_kv_csi.tf
@@ -20,7 +20,7 @@ locals {
   helm_kv_csi_name    = "kvsecrets"
   helm_kv_csi_ns      = "kvsecrets"
   helm_kv_csi_repo    = "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts"
-  helm_kv_csi_version = "0.0.9"
+  helm_kv_csi_version = "0.0.13"
 }
 
 resource "kubernetes_namespace" "kvsecrets" {


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [YES] My code follows the code style of this project.


## Current Behavior or Linked Issues
-------------------------------------
GitLab Issue [#7 ](https://community.opengroup.org/osdu/platform/deployment-and-operations/infra-azure-provisioning/-/issues/7)


## Does this introduce a breaking change?
-------------------------------------
- [NO]



## Other information
-------------------------------------

This change ensures that the Keda Version is fully specified at the minor version number.

This change will update the terraform plan with a single update.

```
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # helm_release.kvsecrets will be updated in-place
  ~ resource "helm_release" "kvsecrets" {
        atomic                     = false
        chart                      = "csi-secrets-store-provider-azure"
        cleanup_on_fail            = false
        create_namespace           = false
        dependency_update          = false
        disable_crd_hooks          = false
        disable_openapi_validation = false
        disable_webhooks           = false
        force_update               = false
        id                         = "kvsecrets"
        lint                       = false
        max_history                = 0
        metadata                   = [
            {
                chart     = "csi-secrets-store-provider-azure"
                name      = "kvsecrets"
                namespace = "kvsecrets"
                revision  = 1
                values    = jsonencode(
                    {
                        secrets-store-csi-driver = {
                            linux = {
                                metricsAddr = ":8081"
                            }
                        }
                    }
                )
                version   = "0.0.9"
            },
        ]
        name                       = "kvsecrets"
        namespace                  = "kvsecrets"
        recreate_pods              = false
        render_subchart_notes      = true
        replace                    = false
        repository                 = "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts"
        reset_values               = false
        reuse_values               = false
        skip_crds                  = false
        status                     = "deployed"
        timeout                    = 300
        verify                     = false
      ~ version                    = "0.0.9" -> "0.0.13"
        wait                       = true

        set {
            name  = "secrets-store-csi-driver.linux.metricsAddr"
            value = ":8081"
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
